### PR TITLE
Token::getJobLabel() always returns a string

### DIFF
--- a/src/Entity/Token.php
+++ b/src/Entity/Token.php
@@ -36,7 +36,7 @@ class Token
         return $this->token;
     }
 
-    public function getJobLabel(): ?string
+    public function getJobLabel(): string
     {
         return $this->jobLabel;
     }


### PR DESCRIPTION
Fixes #21