### PR TITLE
Callers to EventFactory::create() should not know about Reference entity

### DIFF
--- a/src/Controller/EventController.php
+++ b/src/Controller/EventController.php
@@ -2,7 +2,6 @@
 
 namespace App\Controller;
 
-use App\Entity\Reference;
 use App\Entity\Token;
 use App\EntityFactory\EventFactory;
 use App\Request\AddEventRequest;
@@ -45,7 +44,8 @@ class EventController
             $tokenEntity->jobLabel,
             $request->sequenceNumber,
             $request->type,
-            new Reference($request->label, $request->reference),
+            $request->label,
+            $request->reference,
             $request->body
         );
 

--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -57,13 +57,14 @@ class Event implements \JsonSerializable
      */
     public function jsonSerialize(): array
     {
-        return [
-            'sequence_number' => $this->sequenceNumber,
-            'job' => $this->job,
-            'type' => $this->type,
-            'label' => $this->reference->getLabel(),
-            'reference' => $this->reference->getReference(),
-            'body' => $this->body,
-        ];
+        return array_merge(
+            [
+                'sequence_number' => $this->sequenceNumber,
+                'job' => $this->job,
+                'type' => $this->type,
+                'body' => $this->body,
+            ],
+            $this->reference->toArray(),
+        );
     }
 }

--- a/src/Entity/Reference.php
+++ b/src/Entity/Reference.php
@@ -38,18 +38,13 @@ class Reference
     }
 
     /**
-     * @return non-empty-string
+     * @return array{label: non-empty-string, reference: non-empty-string}
      */
-    public function getLabel(): string
+    public function toArray(): array
     {
-        return $this->label;
-    }
-
-    /**
-     * @return non-empty-string
-     */
-    public function getReference(): string
-    {
-        return $this->reference;
+        return [
+            'label' => $this->label,
+            'reference' => $this->reference,
+        ];
     }
 }

--- a/src/EntityFactory/EventFactory.php
+++ b/src/EntityFactory/EventFactory.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\EntityFactory;
 
 use App\Entity\Event;
-use App\Entity\Reference;
 use App\Repository\EventRepository;
 
 class EventFactory
@@ -21,12 +20,15 @@ class EventFactory
      * @param positive-int     $sequenceNumber
      * @param non-empty-string $type
      * @param array<mixed>     $body
+     * @param non-empty-string $label
+     * @param non-empty-string $reference
      */
     public function create(
         string $jobLabel,
         int $sequenceNumber,
         string $type,
-        Reference $reference,
+        string $label,
+        string $reference,
         array $body,
     ): Event {
         $event = $this->repository->findOneBy([
@@ -35,8 +37,13 @@ class EventFactory
         ]);
 
         if (null === $event) {
-            $reference = $this->referenceFactory->create($reference->getLabel(), $reference->getReference());
-            $event = new Event($sequenceNumber, $jobLabel, $type, $body, $reference);
+            $event = new Event(
+                $sequenceNumber,
+                $jobLabel,
+                $type,
+                $body,
+                $this->referenceFactory->create($label, $reference)
+            );
 
             $this->repository->add($event);
         }

--- a/tests/Application/AbstractAddEventTest.php
+++ b/tests/Application/AbstractAddEventTest.php
@@ -250,7 +250,7 @@ abstract class AbstractAddEventTest extends AbstractApplicationTest
         $responseData = json_decode($response->getBody()->getContents(), true);
         self::assertIsArray($responseData);
 
-        self::assertSame(
+        self::assertEquals(
             [
                 'sequence_number' => $sequenceNumber,
                 'job' => $jobLabel,

--- a/tests/Unit/Entity/EventTest.php
+++ b/tests/Unit/Entity/EventTest.php
@@ -17,7 +17,7 @@ class EventTest extends TestCase
      */
     public function testJsonSerialize(Event $event, array $expected): void
     {
-        self::assertSame($expected, $event->jsonSerialize());
+        self::assertEquals($expected, $event->jsonSerialize());
     }
 
     /**


### PR DESCRIPTION
Fixes #52